### PR TITLE
Support for Login and Logout Requests

### DIFF
--- a/README
+++ b/README
@@ -129,6 +129,13 @@ auth_token
 Auth secret for accessing private resources on the target server. No default.
 Set it with the `auth` command or copy in the tiddlyweb_user cookie.
 
+The auth_token property will also be set (only if it does not exist already)
+when the server intercepts login requests to
+`/challenge/tiddlywebplugins.tiddlyspace.cookie_form`
+
+If a POST to `/logout` is made and the auth_token exists, it will be removed
+from the configuration.
+
 Examples
 ========
 

--- a/tsapp/__init__.py
+++ b/tsapp/__init__.py
@@ -91,6 +91,27 @@ def _read_config(path):
     return config
 
 
+def delete_config_property(key):
+    """
+    Remove a line of config identified by it's key.
+    """
+    try:
+        existing_data = _read_config('.')
+    except IOError:
+        existing_data = {}
+    existing_data.pop(key)
+
+    def_umask = os.umask(0077)
+    config_file = open('./.tsapp', 'w')
+
+    for key, value in existing_data.iteritems():
+        key = key.strip()
+        value = value.strip()
+        config_file.write('%s:%s\n' % (key, value))
+
+    config_file.close()
+    os.umask(def_umask)
+
 def run_server(args):
     """
     Run a wsgi server which will look locally for content

--- a/tsapp/__init__.py
+++ b/tsapp/__init__.py
@@ -36,10 +36,17 @@ def write_config(new_data):
         existing_data = {}
     existing_data.update(new_data)
 
+    _write_config(existing_data)
+
+
+def _write_config(data):
+    """
+    Do the actual writing of one single config file.
+    """
     def_umask = os.umask(0077)
     config_file = open('./.tsapp', 'w')
 
-    for key, value in existing_data.iteritems():
+    for key, value in data.iteritems():
         key = key.strip()
         value = value.strip()
         config_file.write('%s:%s\n' % (key, value))
@@ -101,16 +108,8 @@ def delete_config_property(key):
         existing_data = {}
     existing_data.pop(key)
 
-    def_umask = os.umask(0077)
-    config_file = open('./.tsapp', 'w')
+    _write_config(existing_data)
 
-    for key, value in existing_data.iteritems():
-        key = key.strip()
-        value = value.strip()
-        config_file.write('%s:%s\n' % (key, value))
-
-    config_file.close()
-    os.umask(def_umask)
 
 def run_server(args):
     """

--- a/tsapp/proxy.py
+++ b/tsapp/proxy.py
@@ -113,7 +113,8 @@ def handle_write(environ, start_response, method, config):
 
     # Intercept any logout attempts and remove the auth_token
     if path == '/logout':
-        delete_config_property('auth_token')
+        if auth_token is not None:
+            delete_config_property('auth_token')
 
         start_response('204 OK', [('Content-type', 'text/plain')])
         return []


### PR DESCRIPTION
The proxy now has the additional behaviour of:
- Intercepting a login request and writing the authentication secret to the configuration file, if not already present.
- Intercepting a logout request and remove the auth_token property from the configuration file, only if already present.
- Always reading the configuration file for each request so that any of the above take immediate effect without a restart.
