### PR TITLE
Handle Unauthorised Logins

### DIFF
--- a/tsapp/__init__.py
+++ b/tsapp/__init__.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 
 def error_exit(code, message=""):

--- a/tsapp/proxy.py
+++ b/tsapp/proxy.py
@@ -105,7 +105,12 @@ def handle_write(environ, start_response, method, config):
                 auth_data = authenticate(config, user, password)
             except Exception, exc:
                 sys.stderr.write('%s\n' % exc)
+                status = exc.getcode()
+                if status == 401:
+                    start_response('401 Unauthorized', [('Content-type', 'text/plain')])
+                    return []
                 sys.exit(1)
+
             write_config({'auth_token': auth_data})
 
         start_response('204 OK', [('Content-type', 'text/plain')])


### PR DESCRIPTION
Return a 401 response to any login requests that cannot be authorised (e.g. invalid username/password).
