### PR TITLE
Config modifications to suit working with a TiddlyWeb server

### DIFF
--- a/README
+++ b/README
@@ -73,7 +73,8 @@ push
 
 Push (via HTTP `PUT`) all the local assets to the target server, in the
 bag named by `<bag name>`. If the bag does not end with `_private` or
-`_public`, then `_public` will be appended.
+`_public`, then `_public` will be appended.  The exception to this is if
+`tiddlyweb_mode` is set (see Configuration below).
 
 Files that have a `.html` or `.tid` extension on the source file will
 have the extension removed on the target.
@@ -87,7 +88,8 @@ push_hard
 
 Push (via HTTP `PUT`) all the local assets to the target server, in the
 bag named by `<bag name>`. If the bag does not end with `_private` or
-`_public`, then `_public` will be appended.
+`_public`, then `_public` will be appended.  The exception to this is if
+`tiddlyweb_mode` is set (see Configuration below).
 
 This command is distinct from `push` in that the target file on the
 server is deleted before the `PUT`.
@@ -165,6 +167,12 @@ application. Originally this was the server provided by the `wsgiref`
 module in the Python stdlib, but this proved to be annoyingly slow.
 Now `CherryPyWSGIServer` is used. An example of using the original
 server [is availble](https://gist.github.com/cdent/5564147).
+
+tiddlyweb_mode
+--------------
+
+If set to True, tsapp does not append `_public` or `_private` to a bag when
+pushing assets.
 
 Examples
 ========

--- a/README
+++ b/README
@@ -174,6 +174,15 @@ tiddlyweb_mode
 If set to True, tsapp does not append `_public` or `_private` to a bag when
 pushing assets.
 
+server_prefix
+-------------
+
+A URL prefix (without any `/`)
+prepended to `/bags/<somebag>/tiddlers/<sometiddler>` that is used when
+looking up, pushing and deleting assets.  This is limited to just a single
+segment e.g. the prefix `web` would complete the path as:
+`/web/bags/<somebag>/tiddlers/<sometiddler>`
+
 Examples
 ========
 

--- a/README.template
+++ b/README.template
@@ -81,6 +81,11 @@ tiddlyweb_mode
 
 ink: tiddlyweb_mode
 
+server_prefix
+-------------
+
+ink: server_prefix
+
 Examples
 ========
 

--- a/README.template
+++ b/README.template
@@ -76,6 +76,11 @@ wsgi_sever
 
 ink: wsgi_server
 
+tiddlyweb_mode
+--------------
+
+ink: tiddlyweb_mode
+
 Examples
 ========
 

--- a/tsapp/__init__.py
+++ b/tsapp/__init__.py
@@ -216,6 +216,7 @@ def _push(args, hard=False):
 
     target_server = config.get('target_server')
     tiddlyweb_mode = config.get('tiddlyweb_mode')
+    server_prefix = config.get('server_prefix')
     target_bag = args[0]
 
     try:
@@ -228,7 +229,7 @@ def _push(args, hard=False):
 
     try:
         push_assets(target_server, target_bag, auth_token,
-                tiddler=tiddler, hard=hard)
+                tiddler=tiddler, hard=hard, server_prefix=server_prefix)
     except Exception, exc:
         sys.stderr.write('%s\n' % exc)
         sys.exit(1)

--- a/tsapp/__init__.py
+++ b/tsapp/__init__.py
@@ -215,6 +215,7 @@ def _push(args, hard=False):
     auth_token = config.get('auth_token')
 
     target_server = config.get('target_server')
+    tiddlyweb_mode = config.get('tiddlyweb_mode')
     target_bag = args[0]
 
     try:
@@ -222,7 +223,7 @@ def _push(args, hard=False):
     except IndexError:
         tiddler = None
 
-    if not '_' in target_bag:
+    if not '_' in target_bag and not(tiddlyweb_mode):
         target_bag = '%s_public' % target_bag
 
     try:

--- a/tsapp/delete.py
+++ b/tsapp/delete.py
@@ -14,8 +14,12 @@ def delete_tiddler(config, bag_name, tiddler_title):
     """
 
     target_server = config['target_server']
+    server_prefix = config.get('server_prefix')
     auth_token = config.get('auth_token')
-    uri = '%s/bags/%s/tiddlers/%s' % (target_server, quote(bag_name, safe=''),
+    uri = 'bags/%s/tiddlers/%s' % (quote(bag_name, safe=''),
             quote(tiddler_title, safe=''))
+    if server_prefix:
+        uri = '%s/%s' % (server_prefix, uri)
+    uri = '%s/%s' % (target_server, uri)
 
     http_write(method='DELETE', uri=uri, auth_token=auth_token)

--- a/tsapp/proxy.py
+++ b/tsapp/proxy.py
@@ -217,6 +217,7 @@ def handle_get(environ, start_response, config):
     """
     auth_token = config.get('auth_token')
     target_server = config.get('target_server')
+    server_prefix = config.get('server_prefix')
 
     query_string = environ.get('QUERY_STRING')
 
@@ -237,7 +238,7 @@ def handle_get(environ, start_response, config):
             except IOError:
                 filehandle = in_assets(path)
                 mime_type = mimetypes.guess_type(path)[0]
-        elif len(path_parts) == 4:
+        elif len(path_parts) == 4 or path_parts[0] == server_prefix:
             local_path = path_parts[-1]
             filehandle = in_assets(local_path)
             mime_type = mimetypes.guess_type(local_path)[0]

--- a/tsapp/push.py
+++ b/tsapp/push.py
@@ -10,7 +10,7 @@ import urllib2
 from .http import http_write
 
 
-def push_assets(server, bag, auth_token, tiddler=None, hard=False):
+def push_assets(server, bag, auth_token, tiddler=None, hard=False, server_prefix=None):
     """
     Push *.html in the local dir and everything in assets
     to server, into the named bag, using the provided
@@ -29,6 +29,8 @@ def push_assets(server, bag, auth_token, tiddler=None, hard=False):
             target_name = target_name.split('/')[-1]
         target_path = '/bags/%s/tiddlers/%s' % (urllib2.quote(bag),
                 urllib2.quote(target_name))
+        if server_prefix:
+            target_path = '/%s%s' % (server_prefix, target_path)
 
         uri = server + target_path
 


### PR DESCRIPTION
A couple of new configuration options.

The first, dubbed "tiddlyweb mode" allows pushing to custom bag names (i.e. not _public or _private as prescribed by TiddlySpace).

The second allows for a server prefix to be included in all URL requests, similar to `server_prefix` in `tiddlywebconfig.py`.

For example a GET using a prefix of "web" would look like:

```
http://host/web/bags/bagname/tiddlers/tiddler
```
