### PR TITLE
Support TiddlyWeb authentication

### DIFF
--- a/README
+++ b/README
@@ -182,8 +182,8 @@ server_prefix
 
 A URL prefix (without any `/`)
 prepended to `/bags/<somebag>/tiddlers/<sometiddler>` that is used when
-looking up, pushing and deleting assets.  This is limited to just a single
-segment e.g. the prefix `web` would complete the path as:
+authenticating, looking up, pushing and deleting assets.  This is limited
+to just a single segment e.g. the prefix `web` would complete the path as:
 `/web/bags/<somebag>/tiddlers/<sometiddler>`
 
 Examples

--- a/README
+++ b/README
@@ -174,6 +174,9 @@ tiddlyweb_mode
 If set to True, tsapp does not append `_public` or `_private` to a bag when
 pushing assets.
 
+This option will also use the tiddlyweb authentication challenger when using
+the `auth` command.
+
 server_prefix
 -------------
 

--- a/tsapp/auth.py
+++ b/tsapp/auth.py
@@ -17,8 +17,12 @@ def authenticate(config, user, password):
 
     post_data = dict(user=user, password=password)
     target = config['target_server']
-    uri = target + '/challenge/tiddlywebplugins.tiddlyspace.cookie_form'
+    tiddlyweb_mode = config.get('tiddlyweb_mode')
 
+    if tiddlyweb_mode:
+        uri = target + '/challenge/cookie_form'
+    else:
+        uri = target + '/challenge/tiddlywebplugins.tiddlyspace.cookie_form'
     # This will always error
     try:
         response, mime_type = http_write(method='POST',

--- a/tsapp/auth.py
+++ b/tsapp/auth.py
@@ -18,11 +18,16 @@ def authenticate(config, user, password):
     post_data = dict(user=user, password=password)
     target = config['target_server']
     tiddlyweb_mode = config.get('tiddlyweb_mode')
+    server_prefix = config.get('server_prefix')
+    uri = target
+
+    if server_prefix:
+        uri = target + '/' + server_prefix
 
     if tiddlyweb_mode:
-        uri = target + '/challenge/cookie_form'
+        uri = uri + '/challenge/cookie_form'
     else:
-        uri = target + '/challenge/tiddlywebplugins.tiddlyspace.cookie_form'
+        uri = uri + '/challenge/tiddlywebplugins.tiddlyspace.cookie_form'
     # This will always error
     try:
         response, mime_type = http_write(method='POST',


### PR DESCRIPTION
When `tiddlyweb_mode` is set, the standard TiddlyWeb authentication challenge URI is used.

If `server_prefix` is set, this will also be included in the URI.
